### PR TITLE
Add POST /flash request throttling

### DIFF
--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -5,6 +5,7 @@ namespace App\Exceptions;
 use Exception;
 use Illuminate\Foundation\Exceptions\Handler as ExceptionHandler;
 use Illuminate\Session\TokenMismatchException;
+use \Symfony\Component\HttpKernel\Exception\HttpException;
 
 class Handler extends ExceptionHandler
 {
@@ -49,11 +50,18 @@ class Handler extends ExceptionHandler
      */
     public function render($request, Exception $exception)
     {
-         if ($exception instanceof TokenMismatchException) {
-              return redirect()
-                  ->back()
-                  ->withInput($request->except('_token'))
-                  ->with('message', 'CSRF token failed; try again!');
+        if ($exception instanceof TokenMismatchException) {
+            return redirect()
+                ->back()
+                ->withInput($request->except('_token'))
+                ->with('error', 'CSRF token failed; try again!');
+        }
+
+        if ($exception instanceof HttpException) {
+            return redirect()
+                ->back()
+                ->withInput($request->except('_token'))
+                ->with('error', "Too many requests; you'll burn the bulb!");
         }
 
         return parent::render($request, $exception);

--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -57,7 +57,7 @@ class Handler extends ExceptionHandler
                 ->with('error', 'CSRF token failed; try again!');
         }
 
-        if ($exception instanceof HttpException) {
+        if ($exception instanceof HttpException && $exception->getStatusCode() == 429) {
             return redirect()
                 ->back()
                 ->withInput($request->except('_token'))

--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -5,7 +5,7 @@ namespace App\Exceptions;
 use Exception;
 use Illuminate\Foundation\Exceptions\Handler as ExceptionHandler;
 use Illuminate\Session\TokenMismatchException;
-use \Symfony\Component\HttpKernel\Exception\HttpException;
+use Symfony\Component\HttpKernel\Exception\HttpException;
 
 class Handler extends ExceptionHandler
 {
@@ -54,14 +54,14 @@ class Handler extends ExceptionHandler
             return redirect()
                 ->back()
                 ->withInput($request->except('_token'))
-                ->with('error', 'CSRF token failed; try again!');
+                ->with('error-message', 'CSRF token failed; try again!');
         }
 
         if ($exception instanceof HttpException && $exception->getStatusCode() == 429) {
             return redirect()
                 ->back()
                 ->withInput($request->except('_token'))
-                ->with('error', "Too many requests; you'll burn the bulb!");
+                ->with('error-message', "Too many requests; you'll burn the bulb!");
         }
 
         return parent::render($request, $exception);

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -67,13 +67,13 @@
                 margin-bottom: 30px;
             }
 
-            .error {
-                color: #B52F2F;
+            .message--error {
+                color: #b52f2f;
                 font-weight: bold;
             }
 
-            .success {
-                color: #28B4CF;
+            .message--success {
+                color: #28b4cf;
                 font-weight: bold;
             }
         </style>
@@ -85,12 +85,12 @@
                     Blink {{ config('app.name') }} Light
                 </div>
 
-                @if (session()->has('success'))
-                <p class="success">{{ session('success') }}</p>
+                @if (session()->has('success-message'))
+                    <p class="message--success">{{ session('success-message') }}</p>
                 @endif
 
-                @if (session()->has('error'))
-                <p class="error">{{ session('error') }}</p>
+                @if (session()->has('error-message'))
+                    <p class="message--error">{{ session('error-message') }}</p>
                 @endif
 
                 <div class="links">

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -66,6 +66,16 @@
             .m-b-md {
                 margin-bottom: 30px;
             }
+
+            .error {
+                color: #B52F2F;
+                font-weight: bold;
+            }
+
+            .success {
+                color: #28B4CF;
+                font-weight: bold;
+            }
         </style>
     </head>
     <body>
@@ -75,8 +85,12 @@
                     Blink {{ config('app.name') }} Light
                 </div>
 
-                @if (session()->has('message'))
-                <p>{{ session('message') }}</p>
+                @if (session()->has('success'))
+                <p class="success">{{ session('success') }}</p>
+                @endif
+
+                @if (session()->has('error'))
+                <p class="error">{{ session('error') }}</p>
                 @endif
 
                 <div class="links">

--- a/routes/web.php
+++ b/routes/web.php
@@ -6,13 +6,11 @@ Route::get('/', function () {
     return view('welcome');
 });
 
-Route::middleware('throttle:50,1')->group(function () {
-    Route::post('flash', function () {
-        dispatch(new BlinkLight(request('color')));
+Route::post('flash', function () {
+    dispatch(new BlinkLight(request('color')));
 
-        return redirect('/')->with('success', 'Your blink has been queued!');
-    });
-});
+    return redirect('/')->with('success-message', 'Your blink has been queued!');
+})->middleware('throttle:50,1');
 
 Route::get('flash', function () {
     return redirect('/');

--- a/routes/web.php
+++ b/routes/web.php
@@ -6,10 +6,12 @@ Route::get('/', function () {
     return view('welcome');
 });
 
-Route::post('flash', function () {
-    dispatch(new BlinkLight(request('color')));
+Route::middleware('throttle:50,1')->group(function () {
+    Route::post('flash', function () {
+        dispatch(new BlinkLight(request('color')));
 
-    return redirect('/')->with('message', 'Your blink has been queued!');
+        return redirect('/')->with('success', 'Your blink has been queued!');
+    });
 });
 
 Route::get('flash', function () {


### PR DESCRIPTION
This PR adds throttling of 50 requests per minute on the `POST /flash` route. 

Additionally has small tweaks to the main view to distinguish between a successful and erroneous message.

Examples of three message/error types:

<img width="354" alt="blink matt s lights 2018-02-07 14-11-18" src="https://user-images.githubusercontent.com/43112/35939417-b1b6c534-0c11-11e8-8d8a-7070e573f996.png">
<img width="354" alt="blink matt s lights 2018-02-07 14-11-41" src="https://user-images.githubusercontent.com/43112/35939421-b5c97bda-0c11-11e8-9b6a-54b1451bfd67.png">
<img width="354" alt="blink matt s lights 2018-02-07 14-11-07" src="https://user-images.githubusercontent.com/43112/35939425-b85f70a2-0c11-11e8-9ae2-a58103b39e2c.png">

